### PR TITLE
Hero section bug fix

### DIFF
--- a/src/css/layout/hero.css
+++ b/src/css/layout/hero.css
@@ -1,23 +1,21 @@
 /*=============== HERO SECTION ===============*/
-.hero-section .container {
-    display: flex;
-    flex-direction: column;
-    justify-content: end;
-    align-items: center;
-
+.hero-section {
+    padding-top: 260px;
     padding-bottom: 243px;
     min-height: 753px;
 }
 
 @media only screen and (min-width: 768px) {
-    .hero-wrapper {
+    .hero-section {
+        padding-top: 345px;
         padding-bottom: 150px;
         min-height: 895px;
    }
 }
 
 @media only screen and (min-width: 1280px) {
-    .hero-wrapper {
+    .hero-section {
+        padding-top: 235px;
         padding-bottom: 180px;
         min-height: 765px;
     }
@@ -32,6 +30,8 @@
     letter-spacing: -0.02em;
     text-align: center;
 
+    margin-left: auto;
+    margin-right: auto;
     margin-bottom: 24px;
 
     max-width: 335px;
@@ -61,6 +61,8 @@
     line-height: 1.17;
     text-align: center;
 
+    margin-left: auto;
+    margin-right: auto;
     margin-bottom: 38px;
 
     max-width: 335px;


### PR DESCRIPTION
I fixed hero section according to the comments from mentor. And here is a list of all the changes that I made in this fix:

1. I fixed my previous mistake that I haven't noticed at the previous time: there was no "hero-wrapper" class in html. Instead there was a "container" class on the div in the "hero-section". So "hero-wrapper" class in css didn't work. But now there is even no need in the "hero-wrapper" class in the html, because now instead of using styles on the div, I use them on the section, so now there is .hero-section class in the css.
2. I added padding-top to the hero-section
3. I deleted all of the "flex" properties from the container class and added margin-left, margin-right to the title and text in the section with value "auto", so that they will leave in the middle of the screen